### PR TITLE
Fix assisted tackles (#85)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: nflfastR
 Title: Functions to Efficiently Access NFL Play by Play Data
-Version: 2.2.1.9005
+Version: 2.2.1.9006
 Authors@R: 
     c(person(given = "Sebastian",
              family = "Carl",

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@ This is mostly useless as it doesn't work for 2020 and provides less info
 * Fix empty line causing `fast_scraper()` to fail (affects multiple games of the 2020 season)
 * Fix bug in `fixed_drive` that counted PAT after defensive TD as its own drive
 * `clean_pbp()`, `add_qb_epa()` and `add_xyac()` can now handle empty data frames
+* Fixed a bug which caused too high number of tackles in special cases (#85)
 
 # nflfastR 2.2.1
 

--- a/R/helper_tidy_play_stats.R
+++ b/R/helper_tidy_play_stats.R
@@ -819,102 +819,46 @@ sum_play_stats <- function(play_Id, stats) {
           row$solo_tackle_2_team
         )
     } else if (stat_id == 80) {
-      row$assist_tackle <- 1
-      row$assist_tackle_1_player_id <-
+      row$tackle_with_assist <- 1
+      row$tackle_with_assist_1_player_id <-
         if_else(
-          is.na(row$assist_tackle_1_player_id),
+          is.na(row$tackle_with_assist_1_player_id),
           play_stats$player.esbId[index],
-          row$assist_tackle_1_player_id
+          row$tackle_with_assist_1_player_id
         )
-      row$assist_tackle_1_player_name <-
+      row$tackle_with_assist_1_player_name <-
         if_else(
-          is.na(row$assist_tackle_1_player_name),
+          is.na(row$tackle_with_assist_1_player_name),
           play_stats$player.displayName[index],
-          row$assist_tackle_1_player_name
+          row$tackle_with_assist_1_player_name
         )
-      row$assist_tackle_1_team <-
+      row$tackle_with_assist_1_team <-
         if_else(
-          is.na(row$assist_tackle_1_team),
+          is.na(row$tackle_with_assist_1_team),
           play_stats$teamAbbr[index],
-          row$assist_tackle_1_team
+          row$tackle_with_assist_1_team
         )
-      row$assist_tackle_2_player_id <-
+      row$tackle_with_assist_2_player_id <-
         if_else(
-          is.na(row$assist_tackle_2_player_id) &
-            row$assist_tackle_1_player_id != play_stats$player.esbId[index],
+          is.na(row$tackle_with_assist_2_player_id) &
+            row$tackle_with_assist_1_player_id != play_stats$player.esbId[index],
           play_stats$player.esbId[index],
-          row$assist_tackle_2_player_id
+          row$tackle_with_assist_2_player_id
         )
-      row$assist_tackle_2_player_name <-
+      row$tackle_with_assist_2_player_name <-
         if_else(
-          is.na(row$assist_tackle_2_player_name) &
-            row$assist_tackle_1_player_name != play_stats$player.displayName[index],
+          is.na(row$tackle_with_assist_2_player_name) &
+            row$tackle_with_assist_1_player_name != play_stats$player.displayName[index],
           play_stats$player.displayName[index],
-          row$assist_tackle_2_player_name
+          row$tackle_with_assist_2_player_name
         )
-      row$assist_tackle_2_team <-
+      row$tackle_with_assist_2_team <-
         if_else(
-          is.na(row$assist_tackle_2_team) &
-            row$assist_tackle_1_player_name != play_stats$player.displayName[index],
-            # row$assist_tackle_1_team != play_stats$teamAbbr[index],
+          is.na(row$tackle_with_assist_2_team) &
+            row$tackle_with_assist_1_player_name != play_stats$player.displayName[index],
+            # row$tackle_with_assist_1_team != play_stats$teamAbbr[index],
           play_stats$teamAbbr[index],
-          row$assist_tackle_2_team
-        )
-      row$assist_tackle_3_player_id <-
-        if_else(
-          (is.na(row$assist_tackle_3_player_id) &
-            row$assist_tackle_1_player_id != play_stats$player.esbId[index] &
-             row$assist_tackle_2_player_id != play_stats$player.esbId[index]),
-          play_stats$player.esbId[index],
-          row$assist_tackle_3_player_id
-        )
-      row$assist_tackle_3_player_name <-
-        if_else(
-          (is.na(row$assist_tackle_3_player_name) &
-            row$assist_tackle_1_player_name != play_stats$player.displayName[index] &
-             row$assist_tackle_2_player_name != play_stats$player.displayName[index]),
-          play_stats$player.displayName[index],
-          row$assist_tackle_3_player_name
-        )
-      row$assist_tackle_3_team <-
-        if_else(
-          (is.na(row$assist_tackle_3_team) &
-             row$assist_tackle_1_player_name != play_stats$player.displayName[index] &
-             row$assist_tackle_2_player_name != play_stats$player.displayName[index]),
-             # row$assist_tackle_1_team != play_stats$teamAbbr[index] &
-             #  row$assist_tackle_2_team != play_stats$teamAbbr[index]),
-          play_stats$teamAbbr[index],
-          row$assist_tackle_3_team
-        )
-      row$assist_tackle_4_player_id <-
-        if_else(
-          (is.na(row$assist_tackle_4_player_id) &
-            row$assist_tackle_1_player_id != play_stats$player.esbId[index] &
-             row$assist_tackle_2_player_id != play_stats$player.esbId[index] &
-             row$assist_tackle_3_player_id != play_stats$player.esbId[index]),
-          play_stats$player.esbId[index],
-          row$assist_tackle_4_player_id
-        )
-      row$assist_tackle_4_player_name <-
-        if_else(
-          (is.na(row$assist_tackle_4_player_name) &
-            row$assist_tackle_1_player_name != play_stats$player.displayName[index] &
-             row$assist_tackle_2_player_name != play_stats$player.displayName[index] &
-             row$assist_tackle_3_player_name != play_stats$player.displayName[index]),
-          play_stats$player.displayName[index],
-          row$assist_tackle_4_player_name
-        )
-      row$assist_tackle_4_team <-
-        if_else(
-          (is.na(row$assist_tackle_4_team) &
-             row$assist_tackle_1_player_name != play_stats$player.displayName[index] &
-             row$assist_tackle_2_player_name != play_stats$player.displayName[index] &
-             row$assist_tackle_3_player_name != play_stats$player.displayName[index]),
-            # row$assist_tackle_1_team != play_stats$teamAbbr[index] &
-            #  row$assist_tackle_2_team != play_stats$teamAbbr[index] &
-            #  row$assist_tackle_3_team != play_stats$teamAbbr[index]),
-          play_stats$teamAbbr[index],
-          row$assist_tackle_4_team
+          row$tackle_with_assist_2_team
         )
     } else if (stat_id == 82) { # =81
       row$assist_tackle <- 1
@@ -1443,6 +1387,14 @@ pbp_stat_columns <-
     "assist_tackle_4_player_id",
     "assist_tackle_4_player_name",
     "assist_tackle_4_team",
+    # new for stat ID 80 -> tackle_with_assist
+    "tackle_with_assist_1_player_id",
+    "tackle_with_assist_1_player_name",
+    "tackle_with_assist_1_team",
+    "tackle_with_assist_2_player_id",
+    "tackle_with_assist_2_player_name",
+    "tackle_with_assist_2_team",
+
     "pass_defense_1_player_id",
     "pass_defense_1_player_name",
     "pass_defense_2_player_id",
@@ -1550,6 +1502,9 @@ indicator_stats <- c(
   "fumble",
   "complete_pass",
   "assist_tackle",
+  # new for stat ID 80 -> tackle_with_assist
+  "tackle_with_assist",
+
   "lateral_reception",
   "lateral_rush",
   "lateral_return",


### PR DESCRIPTION
Implemented new "tackle_with_assist" variables in `sum_play_stats()`.

The variables don't appear in the output as long as we don't add them to `select_variables()`

If we want them in the output we have to add them to `select_variables()` and also document them in `fast_scraper()`