### PR TITLE
Optimize `decode_player_ids()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: nflfastR
 Title: Functions to Efficiently Access NFL Play by Play Data
-Version: 2.2.1.9008
+Version: 2.2.1.9009
 Authors@R: 
     c(person(given = "Sebastian",
              family = "Carl",

--- a/R/helper_decode_player_ids.R
+++ b/R/helper_decode_player_ids.R
@@ -11,6 +11,8 @@
 #' \code{passer_id}, \code{rusher_id}, \code{receiver_id}, \code{id} of an
 #' nflfastR play-by-play Data set and decode the player IDs to the commonly
 #' known GSIS ID format 00-00xxxxx.
+#' The function requires the package \code{furrr} if the data frame
+#' \code{pbp} has more than 4500 rows.
 #' @return The input Data Frame of the parameter 'pbp' with decoded player IDs.
 #' @importFrom rlang .data
 #' @importFrom dplyr mutate_at vars mutate pull
@@ -19,25 +21,36 @@
 #' @importFrom stringr str_sub str_replace_all str_length
 #' @export
 decode_player_ids <- function(pbp) {
-  if (!requireNamespace("furrr", quietly = TRUE)) {
-    stop("Package \"furrr\" needed to run this function. Please install/load it.")
+  if (!requireNamespace("furrr", quietly = TRUE) & nrow(pbp) > 4500) {
+    stop("Package \"furrr\" required to decode big data frames. Please install/load it.")
+  } else if (requireNamespace("furrr", quietly = TRUE) & nrow(pbp) > 4500) {
+    message("Start decoding, please wait...")
+    future::plan("multiprocess")
+    pp <- TRUE
+  } else {
+    message("Start decoding, please wait...")
+    pp <- FALSE
   }
-  message("Start decoding, please wait...")
-  future::plan("multiprocess")
+
   ret <- pbp %>%
     dplyr::mutate_at(
-      dplyr::vars(tidyselect::any_of(c(
-        "passer_id", "rusher_id", "receiver_id", "id",
+      dplyr::vars(
+        tidyselect::any_of(c("passer_id", "rusher_id", "receiver_id", "id")),
         tidyselect::ends_with("player_id")
-      ))),
-      decode_ids
+      ),
+      decode_ids, pp
     )
   message("Decoding completed.")
   return(ret)
 }
 
-decode_ids <- function(var) {
-  return(furrr::future_map_chr(var, convert_to_gsis_id))
+decode_ids <- function(var, parproc = FALSE) {
+  if (parproc == TRUE) {
+    ret <- furrr::future_map_chr(var, convert_to_gsis_id)
+  } else {
+    ret <- purrr::map_chr(var, convert_to_gsis_id)
+  }
+  return(ret)
 }
 
 convert_to_gsis_id <- function(new_id) {

--- a/man/decode_player_ids.Rd
+++ b/man/decode_player_ids.Rd
@@ -20,4 +20,6 @@ Take all columns ending with \code{player_id} as well as
 \code{passer_id}, \code{rusher_id}, \code{receiver_id}, \code{id} of an
 nflfastR play-by-play Data set and decode the player IDs to the commonly
 known GSIS ID format 00-00xxxxx.
+The function requires the package \code{furrr} if the data frame
+\code{pbp} has more than 4500 rows.
 }


### PR DESCRIPTION
Use purrr for small samples 
really decode all player id columns (the `tidyselect::ends_with()` part didn't work as I had it inside `tidyselect::any_of()`)