### PR TITLE
CRAN v3.2.0

### DIFF
--- a/CRAN-RELEASE
+++ b/CRAN-RELEASE
@@ -1,0 +1,2 @@
+This package was submitted to CRAN on 2020-11-20.
+Once it is accepted, delete this file and tag the release (commit 95ce0c9).

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: nflfastR
 Title: Functions to Efficiently Access NFL Play by Play Data
-Version: 3.1.1.9004
+Version: 3.2.0
 Authors@R: 
     c(person(given = "Sebastian",
              family = "Carl",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# nflfastR (development version)
+# nflfastR 3.2.0
 
 * Performance update for win probability model with point spread (`vegas_wp`)
 * Added `yardline_100` as an input to both win probability models (not having it included was an oversight)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,12 @@
 # nflfastR 3.2.0
 
+## Models
+
 * Performance update for win probability model with point spread (`vegas_wp`)
 * Added `yardline_100` as an input to both win probability models (not having it included was an oversight)
+
+## Minor improvements and fixes
+
 * Fixed a bug where `series` was increased on PATs
 * Fixed a bug affecting the week 10 Raiders-Broncos game
 * Added the column `team_wordmark` - which contains URLs to the team's wordmarks - to the included data frame `?teams_colors_logos`

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,14 +1,7 @@
-## Resbumission
-
-This is a resubmission. The package URL in `DESCRIPTION` was updated as the 
-original Github URL is now being redirected. A similar adjustment of the URL was 
-also made in `man/clean_pbp.Rd`
-
 ## Release summary
 
 This is a minor release that 
-* adds the new exported function `build_nflfastR_pbp()`
-* adds two new dependencies `usethis` and `gsisdecoder`
+* adds a variable to an included data frame and
 * fixes some minor bugs.
 
 ## Test environments


### PR DESCRIPTION
Had to resave `R/sysdata.rda` with another compression method to save filespace because the source tarball was > 5MB (causes a new CRAN NOTE). We are very close to the limit now.