### PR TITLE
Fix safety_team for non-scoring live games

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: nflfastR
 Title: Functions to Efficiently Access NFL Play by Play Data
-Version: 3.2.0.9004
+Version: 3.2.0.9005
 Authors@R: 
     c(person(given = "Sebastian",
              family = "Carl",

--- a/R/helper_scrape_nfl.R
+++ b/R/helper_scrape_nfl.R
@@ -275,7 +275,8 @@ get_pbp_nfl <- function(id, dir = NULL) {
           ),
           drive_real_start_time = as.character(.data$drive_real_start_time),
           # get the safety team to ensure the correct team gets the points
-          safety_team = dplyr::if_else(.data$safety == 1, .data$scoring_team_abbreviation, NA_character_)
+          # usage of base ifelse is important here for non-scoring games (i.e. early live games)
+          safety_team = ifelse(.data$safety == 1, .data$scoring_team_abbreviation, NA_character_)
         ) %>%
         dplyr::mutate_all(dplyr::na_if, "")
 


### PR DESCRIPTION
I didn't add this to NEWS as the normal user can't run into the corresponding bug