### PR TITLE
Really drop existing variables in calculators

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: nflfastR
 Title: Functions to Efficiently Access NFL Play by Play Data
-Version: 3.2.0.9006
+Version: 3.2.0.9007
 Authors@R: 
     c(person(given = "Sebastian",
              family = "Carl",

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@
 * Added field descriptions dataframe and article
 * Tuned spread-adjusted win probability model one final (?) time. Expected points is now no longer 
 required for `calculate_win_probability()`
+* Fixed a bug where `calculate_expected_points()` and `calculate_win_probability()` duplicated some existing variables instead of replacing them (#170)
 
 # nflfastR 3.2.0
 

--- a/R/ep_wp_calculators.R
+++ b/R/ep_wp_calculators.R
@@ -39,14 +39,15 @@
 #' @importFrom stats predict
 #' @export
 calculate_expected_points <- function(pbp_data) {
+
+   # drop existing values of ep and the probs before making new ones
+  pbp_datata <- pbp_data %>% dplyr::select(-tidyselect::any_of(drop.cols))
+
   suppressWarnings(
     model_data <- pbp_data %>%
-      # drop existing values of ep and the probs before making new ones
-      dplyr::select(-any_of(drop.cols)) %>%
       make_model_mutations() %>%
       ep_model_select()
   )
-
 
   preds <- as.data.frame(
     matrix(stats::predict(ep_model, as.matrix(model_data)), ncol = 7, byrow = TRUE)
@@ -119,10 +120,12 @@ drop.cols <- c(
 #' @importFrom tibble as_tibble
 #' @export
 calculate_win_probability <- function(pbp_data) {
+
+  # drop existing values of ep and the probs before making new ones
+  pbp_data <- pbp_data %>% dplyr::select(-tidyselect::any_of(drop.cols.wp))
+
   suppressWarnings(
     model_data <- pbp_data %>%
-      # drop existing values of ep and the probs before making new ones
-      dplyr::select(-any_of(drop.cols.wp)) %>%
       dplyr::mutate(
         home = dplyr::if_else(.data$posteam == .data$home_team, 1, 0),
         posteam_spread = dplyr::if_else(.data$home == 1, .data$spread_line, -1 * .data$spread_line),

--- a/R/ep_wp_calculators.R
+++ b/R/ep_wp_calculators.R
@@ -38,10 +38,29 @@
 #' @importFrom tidyselect any_of
 #' @importFrom stats predict
 #' @export
+#' @examples
+#' \donttest{
+#' library(dplyr)
+#' data <- tibble::tibble(
+#' "season" = 1999:2019,
+#' "home_team" = "SEA",
+#' "posteam" = "SEA",
+#' "roof" = "outdoors",
+#' "half_seconds_remaining" = 1800,
+#' "yardline_100" = c(rep(80, 17), rep(75, 4)),
+#' "down" = 1,
+#' "ydstogo" = 10,
+#' "posteam_timeouts_remaining" = 3,
+#' "defteam_timeouts_remaining" = 3
+#' )
+#'
+#' nflfastR::calculate_expected_points(data) %>%
+#'   dplyr::select(season, yardline_100, td_prob, ep)
+#' }
 calculate_expected_points <- function(pbp_data) {
 
    # drop existing values of ep and the probs before making new ones
-  pbp_datata <- pbp_data %>% dplyr::select(-tidyselect::any_of(drop.cols))
+  pbp_data <- pbp_data %>% dplyr::select(-tidyselect::any_of(drop.cols))
 
   suppressWarnings(
     model_data <- pbp_data %>%
@@ -119,6 +138,27 @@ drop.cols <- c(
 #' @importFrom stats predict
 #' @importFrom tibble as_tibble
 #' @export
+#' @examples
+#' \donttest{
+#' library(dplyr)
+#' data <- tibble::tibble(
+#' "receive_2h_ko" = 0,
+#' "home_team" = "SEA",
+#' "posteam" = "SEA",
+#' "score_differential" = 0,
+#' "half_seconds_remaining" = 1800,
+#' "game_seconds_remaining" = 3600,
+#' "spread_line" = c(1, 3, 4, 7, 14),
+#' "down" = 1,
+#' "ydstogo" = 10,
+#' "yardline_100" = 75,
+#' "posteam_timeouts_remaining" = 3,
+#' "defteam_timeouts_remaining" = 3
+#' )
+#'
+#' nflfastR::calculate_win_probability(data) %>%
+#'   dplyr::select(spread_line, wp, vegas_wp)
+#' }
 calculate_win_probability <- function(pbp_data) {
 
   # drop existing values of ep and the probs before making new ones

--- a/R/helper_add_ep_wp.R
+++ b/R/helper_add_ep_wp.R
@@ -855,8 +855,6 @@ add_wp_variables <- function(pbp_data) {
       posteam = if_else(.data$home_team == .data$posteam, .data$away_team, .data$home_team),
       yardline_100 = 75
     ) %>%
-    select(-"ep") %>%
-    calculate_expected_points() %>%
     dplyr::mutate(
       home = case_when(
         .data$home == 0 ~ 1,

--- a/man/calculate_expected_points.Rd
+++ b/man/calculate_expected_points.Rd
@@ -46,3 +46,23 @@ must be present:
 \item{defteam_timeouts_remaining}
 }
 }
+\examples{
+\donttest{
+library(dplyr)
+data <- tibble::tibble(
+"season" = 1999:2019,
+"home_team" = "SEA",
+"posteam" = "SEA",
+"roof" = "outdoors",
+"half_seconds_remaining" = 1800,
+"yardline_100" = c(rep(80, 17), rep(75, 4)),
+"down" = 1,
+"ydstogo" = 10,
+"posteam_timeouts_remaining" = 3,
+"defteam_timeouts_remaining" = 3
+)
+
+nflfastR::calculate_expected_points(data) \%>\%
+  dplyr::select(season, yardline_100, td_prob, ep)
+}
+}

--- a/man/calculate_win_probability.Rd
+++ b/man/calculate_win_probability.Rd
@@ -44,3 +44,25 @@ must be present:
 \item{defteam_timeouts_remaining}
 }
 }
+\examples{
+\donttest{
+library(dplyr)
+data <- tibble::tibble(
+"receive_2h_ko" = 0,
+"home_team" = "SEA",
+"posteam" = "SEA",
+"score_differential" = 0,
+"half_seconds_remaining" = 1800,
+"game_seconds_remaining" = 3600,
+"spread_line" = c(1, 3, 4, 7, 14),
+"down" = 1,
+"ydstogo" = 10,
+"yardline_100" = 75,
+"posteam_timeouts_remaining" = 3,
+"defteam_timeouts_remaining" = 3
+)
+
+nflfastR::calculate_win_probability(data) \%>\%
+  dplyr::select(spread_line, wp, vegas_wp)
+}
+}


### PR DESCRIPTION
This PR closes #170 

``` r
library(tidyverse)

data <- tibble::tibble(
  "receive_2h_ko" = 0,
  "home_team" = "SEA",
  "posteam" = "SEA",
  "score_differential" = 0,
  "half_seconds_remaining" = 1800,
  "game_seconds_remaining" = 3600,
  "spread_line" = 1,
  "down" = 1,
  "ydstogo" = 10,
  "yardline_100" = 75,
  "posteam_timeouts_remaining" = 3,
  "defteam_timeouts_remaining" = 3
)

nflfastR::calculate_win_probability(
  data %>% mutate(vegas_wp = .9)
) %>%
  pull(vegas_wp)
#> [1] 0.5147206
```

<sup>Created on 2021-01-30 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>