### PR TITLE
fix posteam for end Q2 and end Q4 plays

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: nflfastR
 Title: Functions to Efficiently Access NFL Play by Play Data
-Version: 4.0.0.9003
+Version: 4.0.0.9004
 Authors@R: 
     c(person(given = "Sebastian",
              family = "Carl",

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,8 @@
 * Added the function `load_player_stats()` that loads weekly player stats from 1999 to the most recent season
 * Fix bug in `drive` that was causing incorrect overtime win probabilities (#194)
 * The performance of `add_xyac()` has been significantly improved
-* Fixed a bug where `posteam` was not `NA` on end of quarter 2 (or end of quarter 4 in overtime games) causing wrong values for `fixed_drive` and `fixed_drive_result`
+* Fixed a bug where `posteam` was not `NA` on end of quarter 2 (or end of quarter 4 in overtime games) causing wrong values for `fixed_drive`, `fixed_drive_result`, `series` and `series_result`
+* Fixed a bug where `fixed_drive` and `series` were falsely incrementing on kickoffs recovered by the kicking team
 
 # nflfastR 4.0.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,7 @@
 * Added the function `load_player_stats()` that loads weekly player stats from 1999 to the most recent season
 * Fix bug in `drive` that was causing incorrect overtime win probabilities (#194)
 * The performance of `add_xyac()` has been significantly improved
-* Fixed a bug where `posteam` was not `NA` on end of quarter 2 (or end of quarter 4 in overtime games) causing wrong value for `fixed_drive` and `fixed_drive_result`
+* Fixed a bug where `posteam` was not `NA` on end of quarter 2 (or end of quarter 4 in overtime games) causing wrong values for `fixed_drive` and `fixed_drive_result`
 
 # nflfastR 4.0.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 * Added the function `load_player_stats()` that loads weekly player stats from 1999 to the most recent season
 * Fix bug in `drive` that was causing incorrect overtime win probabilities (#194)
 * The performance of `add_xyac()` has been significantly improved
+* Fixed a bug where `posteam` was not `NA` on end of quarter 2 (or end of quarter 4 in overtime games) causing wrong value for `fixed_drive` and `fixed_drive_result`
 
 # nflfastR 4.0.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,8 @@
 * Fix bug in `drive` that was causing incorrect overtime win probabilities (#194)
 * The performance of `add_xyac()` has been significantly improved
 * Fixed a bug where `posteam` was not `NA` on end of quarter 2 (or end of quarter 4 in overtime games) causing wrong values for `fixed_drive`, `fixed_drive_result`, `series` and `series_result`
-* Fixed a bug where `fixed_drive` and `series` were falsely incrementing on kickoffs recovered by the kicking team
+* Fixed a bug where `fixed_drive` and `series` were falsely incrementing on kickoffs recovered by the kicking team or on defensive touchdowns followed by timeouts
+* Fixed a bug where `fixed_drive` and `series` were falsely incrementing on muffed punts recovered by the punting team for a touchdown
 
 # nflfastR 4.0.0
 

--- a/R/helper_add_fixed_drives.R
+++ b/R/helper_add_fixed_drives.R
@@ -47,7 +47,7 @@ add_drive_results <- function(d) {
         .data$new_drive),
       # PAT after defensive TD is not a new drive even if a Timeout follows the TD
       new_drive = dplyr::if_else(
-        dplyr::lag(stringr::str_detect(.data$desc, "Timeout")) &
+        dplyr::lag(stringr::str_detect(.data$desc, "(Timeout)|(Two-Minute Warning)")) &
           dplyr::lag(.data$touchdown == 1, 2L) &
           (dplyr::lag(.data$posteam, 2L) != dplyr::lag(.data$td_team, 2L)),
         0,

--- a/R/helper_add_fixed_drives.R
+++ b/R/helper_add_fixed_drives.R
@@ -45,6 +45,14 @@ add_drive_results <- function(d) {
           & !is.na(dplyr::lag(.data$posteam)),
         0,
         .data$new_drive),
+      # PAT after defensive TD is not a new drive even if a Timeout follows the TD
+      new_drive = dplyr::if_else(
+        dplyr::lag(stringr::str_detect(.data$desc, "Timeout")) &
+          dplyr::lag(.data$touchdown == 1, 2L) &
+          (dplyr::lag(.data$posteam, 2L) != dplyr::lag(.data$td_team, 2L)),
+        0,
+        .data$new_drive,
+        missing = .data$new_drive),
       # if same team has the ball as prior play, but prior play was a punt with lost fumble, it's a new drive
       new_drive = dplyr::if_else(
         # this line is to prevent it from overwriting already-defined new drives with NA

--- a/R/helper_add_fixed_drives.R
+++ b/R/helper_add_fixed_drives.R
@@ -13,7 +13,14 @@ add_drive_results <- function(d) {
     dplyr::mutate(
       old_posteam = .data$posteam,
       posteam = dplyr::case_when(
+        # on kickoffs the kicking team is the defteam but this should be swapped
+        # in terms of this function if the kickoff is recovered
         .data$own_kickoff_recovery == 1 ~ .data$defteam,
+        # if a kickoff has to be replayed due to a penalty and is then recovered,
+        # the prior (reversed) kickoff shouldn't be a new drive/series
+        stringr::str_detect(.data$desc, kickoff_finder) &
+          .data$own_kickoff_recovery == 0 &
+          dplyr::lead(.data$own_kickoff_recovery == 1) ~ .data$defteam,
         TRUE ~ .data$posteam
       )
     ) %>%

--- a/R/helper_add_fixed_drives.R
+++ b/R/helper_add_fixed_drives.R
@@ -10,6 +10,13 @@
 ##  result of  given drive
 add_drive_results <- function(d) {
   drive_df <- d %>%
+    dplyr::mutate(
+      old_posteam = .data$posteam,
+      posteam = dplyr::case_when(
+        .data$own_kickoff_recovery == 1 ~ .data$defteam,
+        TRUE ~ .data$posteam
+      )
+    ) %>%
     dplyr::group_by(.data$game_id, .data$game_half) %>%
     dplyr::mutate(
       row = 1:dplyr::n(),
@@ -72,7 +79,8 @@ add_drive_results <- function(d) {
         )
     ) %>%
     dplyr::ungroup() %>%
-    dplyr::select(-"row", -"new_drive", -"tmp_result")
+    dplyr::mutate(posteam = .data$old_posteam) %>%
+    dplyr::select(-"row", -"new_drive", -"tmp_result", -"old_posteam")
 
   usethis::ui_done("added fixed drive variables")
   return(drive_df)

--- a/R/helper_add_fixed_drives.R
+++ b/R/helper_add_fixed_drives.R
@@ -53,6 +53,15 @@ add_drive_results <- function(d) {
         0,
         .data$new_drive,
         missing = .data$new_drive),
+      # PAT after defensive TD is not a new drive even if 2 Timeouts follow the TD
+      new_drive = dplyr::if_else(
+        dplyr::lag(stringr::str_detect(.data$desc, "(Timeout)|(Two-Minute Warning)")) &
+          dplyr::lag(stringr::str_detect(.data$desc, "(Timeout)|(Two-Minute Warning)"), 2L) &
+          dplyr::lag(.data$touchdown == 1, 3L) &
+          (dplyr::lag(.data$posteam, 3L) != dplyr::lag(.data$td_team, 3L)),
+        0,
+        .data$new_drive,
+        missing = .data$new_drive),
       # if same team has the ball as prior play, but prior play was a punt with lost fumble, it's a new drive
       new_drive = dplyr::if_else(
         # this line is to prevent it from overwriting already-defined new drives with NA

--- a/R/helper_add_fixed_drives.R
+++ b/R/helper_add_fixed_drives.R
@@ -44,7 +44,10 @@ add_drive_results <- function(d) {
         # when there's a timeout on prior line
         .data$new_drive != 1 &
           # same team has ball after lost fumble on punt
-          .data$posteam == dplyr::lag(.data$posteam) & dplyr::lag(.data$fumble_lost == 1) & dplyr::lag(.data$play_type) == "punt",
+          .data$posteam == dplyr::lag(.data$posteam) & dplyr::lag(.data$fumble_lost == 1) & dplyr::lag(.data$play_type) == "punt" &
+          # but not if the play resulted in a touchdown because otherwise the
+          # following extra point or 2pt conversion will be new drives
+          dplyr::lag(.data$touchdown == 0),
         1, .data$new_drive
       ),
       # first observation of a half is also a new drive

--- a/R/helper_add_fixed_drives.R
+++ b/R/helper_add_fixed_drives.R
@@ -57,7 +57,7 @@ add_drive_results <- function(d) {
         .data$play_type == "punt" | .data$punt_attempt == 1 ~ "Punt",
         .data$interception == 1 | .data$fumble_lost == 1 ~ "Turnover",
         .data$down == 4 & .data$yards_gained < .data$ydstogo & .data$play_type != "no_play" ~ "Turnover on downs",
-        .data$desc %in% c("END GAME", "END QUARTER 2", "END QUARTER 4") ~ "End of half"
+        stringr::str_detect(.data$desc, "(END QUARTER 2)|(END QUARTER 4)|(END GAME)") ~ "End of half"
       )
     ) %>%
     dplyr::group_by(.data$game_id, .data$fixed_drive) %>%

--- a/R/helper_add_nflscrapr_mutations.R
+++ b/R/helper_add_nflscrapr_mutations.R
@@ -54,7 +54,7 @@ add_nflscrapr_mutations <- function(pbp) {
       # remove posteam from END Q2 plays or END Q4 plays (when game goes in OT)
       # because it doesn't make sense and breaks fixed_drive and fixed_drive_result
       posteam = dplyr::if_else(
-        .data$play_description %in% c("END QUARTER 2", "END QUARTER 4"),
+        stringr::str_detect(.data$desc, "(END QUARTER 2)|(END QUARTER 4)"),
         NA_character_, .data$posteam
       ),
 

--- a/R/helper_add_nflscrapr_mutations.R
+++ b/R/helper_add_nflscrapr_mutations.R
@@ -54,7 +54,7 @@ add_nflscrapr_mutations <- function(pbp) {
       # remove posteam from END Q2 plays or END Q4 plays (when game goes in OT)
       # because it doesn't make sense and breaks fixed_drive and fixed_drive_result
       posteam = dplyr::if_else(
-        stringr::str_detect(.data$desc, "(END QUARTER 2)|(END QUARTER 4)"),
+        stringr::str_detect(.data$play_description, "(END QUARTER 2)|(END QUARTER 4)"),
         NA_character_, .data$posteam
       ),
 

--- a/R/helper_add_nflscrapr_mutations.R
+++ b/R/helper_add_nflscrapr_mutations.R
@@ -54,7 +54,7 @@ add_nflscrapr_mutations <- function(pbp) {
       # remove posteam from END Q2 plays or END Q4 plays (when game goes in OT)
       # because it doesn't make sense and breaks fixed_drive and fixed_drive_result
       posteam = dplyr::if_else(
-        .data$desc %in% c("END QUARTER 2", "END QUARTER 4"),
+        .data$play_description %in% c("END QUARTER 2", "END QUARTER 4"),
         NA_character_, .data$posteam
       ),
 

--- a/R/helper_add_nflscrapr_mutations.R
+++ b/R/helper_add_nflscrapr_mutations.R
@@ -51,6 +51,13 @@ add_nflscrapr_mutations <- function(pbp) {
         dplyr::lead(.data$posteam_id),
         .data$posteam_id),
 
+      # remove posteam from END Q2 plays or END Q4 plays (when game goes in OT)
+      # because it doesn't make sense and breaks fixed_drive and fixed_drive_result
+      posteam = dplyr::if_else(
+        .data$desc %in% c("END QUARTER 2", "END QUARTER 4"),
+        NA_character_, .data$posteam
+      ),
+
       # Denote whether the home or away team has possession:
       posteam_type = dplyr::if_else(.data$posteam == .data$home_team, "home", "away"),
 

--- a/R/helper_add_series_data.R
+++ b/R/helper_add_series_data.R
@@ -16,7 +16,14 @@ add_series_data <- function(pbp) {
     dplyr::mutate(
       old_posteam = .data$posteam,
       posteam = dplyr::case_when(
+        # on kickoffs the kicking team is the defteam but this should be swapped
+        # in terms of this function if the kickoff is recovered
         .data$own_kickoff_recovery == 1 ~ .data$defteam,
+        # if a kickoff has to be replayed due to a penalty and is then recovered,
+        # the prior (reversed) kickoff shouldn't be a new drive/series
+        stringr::str_detect(.data$desc, kickoff_finder) &
+          .data$own_kickoff_recovery == 0 &
+          dplyr::lead(.data$own_kickoff_recovery == 1) ~ .data$defteam,
         TRUE ~ .data$posteam
       )
     ) %>%

--- a/R/helper_add_series_data.R
+++ b/R/helper_add_series_data.R
@@ -45,7 +45,7 @@ add_series_data <- function(pbp) {
         .data$interception == 1 | .data$fumble_lost == 1 ~ "Turnover",
         .data$down == 4 & .data$yards_gained < .data$ydstogo & .data$play_type != "no_play" ~ "Turnover on downs",
         .data$qb_kneel == 1 ~ "QB kneel",
-        .data$desc %in% c("END GAME", "END QUARTER 2", "END QUARTER 4") ~ "End of half"
+        stringr::str_detect(.data$desc, "(END QUARTER 2)|(END QUARTER 4)|(END GAME)") ~ "End of half"
       )
     ) %>%
     dplyr::group_by(.data$game_id, .data$series) %>%

--- a/R/helper_add_series_data.R
+++ b/R/helper_add_series_data.R
@@ -13,6 +13,13 @@
 add_series_data <- function(pbp) {
   out <-
     pbp %>%
+    dplyr::mutate(
+      old_posteam = .data$posteam,
+      posteam = dplyr::case_when(
+        .data$own_kickoff_recovery == 1 ~ .data$defteam,
+        TRUE ~ .data$posteam
+      )
+    ) %>%
     dplyr::group_by(.data$game_id, .data$game_half) %>%
     dplyr::mutate(
       row = 1:dplyr::n(),
@@ -63,7 +70,8 @@ add_series_data <- function(pbp) {
       )
     ) %>%
     dplyr::ungroup() %>%
-    dplyr::select(-"row", -"tmp_result", -"new_series")
+    dplyr::mutate(posteam = .data$old_posteam) %>%
+    dplyr::select(-"row", -"tmp_result", -"new_series", -"old_posteam")
 
   usethis::ui_done("added series variables")
   return(out)


### PR DESCRIPTION
The variable `posteam` was **not** `NA` for plays with `desc %in% c("END QUARTER 2", "END QUARTER 4")`.

This broke `fixed_drive` and `fixed_drive_result`.

Since naming a `posteam` on those non-plays doesn't make sense anyway, we set it to `NA` explicitly.