### PR TITLE
add dakota and fix duplicated player names

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: nflfastR
 Title: Functions to Efficiently Access NFL Play by Play Data
-Version: 4.0.0.9006
+Version: 4.0.0.9007
 Authors@R: 
     c(person(given = "Sebastian",
              family = "Carl",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: nflfastR
 Title: Functions to Efficiently Access NFL Play by Play Data
-Version: 4.0.0.9005
+Version: 4.0.0.9006
 Authors@R: 
     c(person(given = "Sebastian",
              family = "Carl",

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,8 +10,9 @@
 * Fixed a bug where `fixed_drive` and `series` were falsely incrementing on kickoffs recovered by the kicking team or on defensive touchdowns followed by timeouts
 * Fixed a bug where `fixed_drive` and `series` were falsely incrementing on muffed punts recovered by the punting team for a touchdown
 * Fixed a bug in `epa` when a safety is scored by the team beginning the play in possession of the ball (#186)
-* The function `calculate_player_stats()` now adds the variable `dakota`, the `epa` + `cpoe` composite, for players with minimum 5 pass plays per game.
+* The function `calculate_player_stats()` now adds the variable `dakota`, the `epa` + `cpoe` composite, for players with minimum 5 pass attempts.
 * Fixed a bug where `calculate_player_stats()` forgot to clean player names by using their IDs
+* Fixed a bug where special teams touchdowns were missing in the output of `calculate_player_stats()` (#203)
 
 # nflfastR 4.0.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,8 @@
 * Fixed a bug where `fixed_drive` and `series` were falsely incrementing on kickoffs recovered by the kicking team or on defensive touchdowns followed by timeouts
 * Fixed a bug where `fixed_drive` and `series` were falsely incrementing on muffed punts recovered by the punting team for a touchdown
 * Fixed a bug in `epa` when a safety is scored by the team beginning the play in possession of the ball (#186)
+* The function `calculate_player_stats()` now adds the variable `dakota`, the `epa` + `cpoe` composite, for players with minimum 5 pass plays per game.
+* Fixed a bug where `calculate_player_stats()` forgot to clean player names by using their IDs
 
 # nflfastR 4.0.0
 

--- a/R/aggregate_game_stats.R
+++ b/R/aggregate_game_stats.R
@@ -149,7 +149,7 @@ calculate_player_stats <- function(pbp, weekly = FALSE) {
       passing_air_yards = sum(.data$air_yards, na.rm = TRUE),
       sacks = sum(.data$sack),
       passing_first_downs = sum(.data$first_down_pass),
-      passing_epa = sum(.data$qb_epa)
+      passing_epa = sum(.data$qb_epa, na.rm = TRUE)
     ) %>%
     dplyr::rename(player_id = .data$passer_player_id) %>%
     dplyr::ungroup()
@@ -191,7 +191,7 @@ calculate_player_stats <- function(pbp, weekly = FALSE) {
       carries = dplyr::n(),
       rushing_fumbles_lost = sum(.data$fumble_lost == 1 & is.na(.data$lateral_rusher_player_id)),
       rushing_first_downs = sum(.data$first_down_rush & is.na(.data$lateral_rusher_player_id)),
-      rushing_epa = sum(.data$epa)
+      rushing_epa = sum(.data$epa, na.rm = TRUE)
     ) %>%
     dplyr::ungroup()
 
@@ -276,7 +276,7 @@ calculate_player_stats <- function(pbp, weekly = FALSE) {
       receiving_air_yards = sum(.data$air_yards, na.rm = TRUE),
       receiving_yards_after_catch = sum(.data$yards_after_catch, na.rm = TRUE),
       receiving_first_downs = sum(.data$first_down_pass & is.na(.data$lateral_receiver_player_id)),
-      receiving_epa = sum(.data$epa)
+      receiving_epa = sum(.data$epa, na.rm = TRUE)
     ) %>%
     dplyr::ungroup()
 

--- a/R/aggregate_game_stats.R
+++ b/R/aggregate_game_stats.R
@@ -345,6 +345,15 @@ calculate_player_stats <- function(pbp, weekly = FALSE) {
 
   rec_df[is.na(rec_df)] <- 0
 
+
+# Special Teams -----------------------------------------------------------
+
+  st_tds <- pbp %>%
+    dplyr::filter(.data$special == 1) %>%
+    dplyr::group_by(.data$td_player_id, .data$week, .data$season) %>%
+    dplyr::summarise(special_teams_tds = sum(.data$touchdown, na.rm = TRUE)) %>%
+    dplyr::rename(player_id = .data$td_player_id)
+
 # Combine all stats -------------------------------------------------------
 
   # combine all the stats together
@@ -490,8 +499,7 @@ add_dakota <- function(add_to_this, pbp, weekly) {
       ) %>%
       dplyr::ungroup() %>%
       dplyr::mutate(cpoe = dplyr::if_else(is.na(.data$cpoe), 0, .data$cpoe)) %>%
-      dplyr::rename(player_id = .data$id) %>%
-      dplyr::filter(n_plays >= 5)
+      dplyr::rename(player_id = .data$id)
 
     model_data$dakota <- mgcv::predict.gam(dakota_model, model_data)
 

--- a/R/aggregate_game_stats.R
+++ b/R/aggregate_game_stats.R
@@ -526,7 +526,7 @@ add_dakota <- function(add_to_this, pbp, weekly) {
       dplyr::rename(player_id = .data$id) %>%
       dplyr::filter(.data$player_id %in% relevant_players)
 
-    model_data$dakota <- mgcv::predict.gam(dakota_model, model_data)
+    model_data$dakota <- mgcv::predict.gam(dakota_model, model_data) %>% as.vector()
 
     out <- add_to_this %>%
       dplyr::left_join(
@@ -547,7 +547,7 @@ add_dakota <- function(add_to_this, pbp, weekly) {
       dplyr::rename(player_id = .data$id) %>%
       dplyr::filter(.data$player_id %in% relevant_players)
 
-    model_data$dakota <- mgcv::predict.gam(dakota_model, model_data)
+    model_data$dakota <- mgcv::predict.gam(dakota_model, model_data) %>% as.vector()
 
     out <- add_to_this %>%
       dplyr::left_join(

--- a/R/aggregate_game_stats.R
+++ b/R/aggregate_game_stats.R
@@ -460,7 +460,12 @@ calculate_player_stats <- function(pbp, weekly = FALSE) {
         fantasy_points_ppr = sum(.data$fantasy_points_ppr)
       ) %>%
       dplyr::ungroup() %>%
-      add_dakota(pbp = pbp, weekly = weekly)
+      add_dakota(pbp = pbp, weekly = weekly) %>%
+      dplyr::select(
+        .data$player_id:.data$passing_2pt_conversions,
+        .data$dakota,
+        dplyr::everything()
+      )
   }
 
   return(player_df)

--- a/R/aggregate_game_stats.R
+++ b/R/aggregate_game_stats.R
@@ -447,7 +447,7 @@ calculate_player_stats <- function(pbp, weekly = FALSE) {
         passing_air_yards = sum(.data$passing_air_yards),
         passing_yards_after_catch = sum(.data$passing_yards_after_catch),
         passing_first_downs = sum(.data$passing_first_downs),
-        passing_epa = sum(.data$passing_epa),
+        passing_epa = sum(.data$passing_epa, na.rm = TRUE),
         passing_2pt_conversions = sum(.data$passing_2pt_conversions),
 
         # rushing
@@ -456,7 +456,7 @@ calculate_player_stats <- function(pbp, weekly = FALSE) {
         rushing_tds = sum(.data$rushing_tds),
         rushing_fumbles_lost = sum(.data$rushing_fumbles_lost),
         rushing_first_downs = sum(.data$rushing_first_downs),
-        rushing_epa = sum(.data$rushing_epa),
+        rushing_epa = sum(.data$rushing_epa, na.rm = TRUE),
         rushing_2pt_conversions = sum(.data$rushing_2pt_conversions),
 
         # receiving
@@ -468,7 +468,7 @@ calculate_player_stats <- function(pbp, weekly = FALSE) {
         receiving_air_yards = sum(.data$receiving_air_yards),
         receiving_yards_after_catch = sum(.data$receiving_yards_after_catch),
         receiving_first_downs = sum(.data$receiving_first_downs),
-        receiving_epa = sum(.data$receiving_epa),
+        receiving_epa = sum(.data$receiving_epa, na.rm = TRUE),
         receiving_2pt_conversions = sum(.data$receiving_2pt_conversions),
 
         # fantasy

--- a/R/aggregate_game_stats.R
+++ b/R/aggregate_game_stats.R
@@ -129,6 +129,15 @@ calculate_player_stats <- function(pbp, weekly = FALSE) {
       decode_player_ids()
   })
 
+  if (!"special" %in% names(pbp)) {# we need this column for the special teams tds
+    pbp <- pbp %>%
+      dplyr::mutate(
+        special = dplyr::if_else(
+          .data$play_type %in% c("extra_point","field_goal","kickoff","punt"),
+          1, 0
+        )
+      )
+  }
 
 # Passing stats -----------------------------------------------------------
 

--- a/R/aggregate_game_stats.R
+++ b/R/aggregate_game_stats.R
@@ -472,7 +472,7 @@ add_dakota <- function(add_to_this, pbp, weekly) {
 
   df <- pbp %>%
     dplyr::filter(.data$pass == 1 | .data$rush == 1) %>%
-    dplyr::filter(!is.na(.data$posteam) & !is.na(.data$qb_epa) & !is.na(.data$id)) %>%
+    dplyr::filter(!is.na(.data$posteam) & !is.na(.data$qb_epa) & !is.na(.data$id) & !is.na(.data$down)) %>%
     dplyr::mutate(epa = dplyr::if_else(.data$qb_epa < -4.5, -4.5, .data$qb_epa))
 
   if (isTRUE(weekly)) {

--- a/R/aggregate_game_stats.R
+++ b/R/aggregate_game_stats.R
@@ -176,7 +176,7 @@ calculate_player_stats <- function(pbp, weekly = FALSE) {
     dplyr::filter(!is.na(.data$player_id))
 
   pass_df_nas <- is.na(pass_df)
-  epa_index <- which(dimnames(pass_df_nas)[[2]] == "passing_epa")
+  epa_index <- which(dimnames(pass_df_nas)[[2]] %in% c("passing_epa", "dakota"))
   pass_df_nas[,epa_index] <- c(FALSE)
 
   pass_df[pass_df_nas] <- 0

--- a/R/aggregate_game_stats.R
+++ b/R/aggregate_game_stats.R
@@ -175,7 +175,11 @@ calculate_player_stats <- function(pbp, weekly = FALSE) {
     dplyr::mutate(passing_2pt_conversions = dplyr::if_else(is.na(.data$passing_2pt_conversions), 0L, .data$passing_2pt_conversions)) %>%
     dplyr::filter(!is.na(.data$player_id))
 
-  pass_df[is.na(pass_df)] <- 0
+  pass_df_nas <- is.na(pass_df)
+  epa_index <- which(dimnames(pass_df_nas)[[2]] == "passing_epa")
+  pass_df_nas[,epa_index] <- c(FALSE)
+
+  pass_df[pass_df_nas] <- 0
 
 # Rushing stats -----------------------------------------------------------
 
@@ -257,7 +261,11 @@ calculate_player_stats <- function(pbp, weekly = FALSE) {
     dplyr::mutate(rushing_2pt_conversions = dplyr::if_else(is.na(.data$rushing_2pt_conversions), 0L, .data$rushing_2pt_conversions)) %>%
     dplyr::filter(!is.na(.data$player_id))
 
-  rush_df[is.na(rush_df)] <- 0
+  rush_df_nas <- is.na(rush_df)
+  epa_index <- which(dimnames(rush_df_nas)[[2]] == "rushing_epa")
+  rush_df_nas[,epa_index] <- c(FALSE)
+
+  rush_df[rush_df_nas] <- 0
 
 # Receiving stats ---------------------------------------------------------
 
@@ -343,7 +351,11 @@ calculate_player_stats <- function(pbp, weekly = FALSE) {
     dplyr::mutate(receiving_2pt_conversions = dplyr::if_else(is.na(.data$receiving_2pt_conversions), 0L, .data$receiving_2pt_conversions)) %>%
     dplyr::filter(!is.na(.data$player_id))
 
-  rec_df[is.na(rec_df)] <- 0
+  rec_df_nas <- is.na(rec_df)
+  epa_index <- which(dimnames(rec_df_nas)[[2]] == "receiving_epa")
+  rec_df_nas[,epa_index] <- c(FALSE)
+
+  rec_df[rec_df_nas] <- 0
 
 
 # Special Teams -----------------------------------------------------------
@@ -394,7 +406,11 @@ calculate_player_stats <- function(pbp, weekly = FALSE) {
     ))) %>%
     dplyr::filter(!is.na(.data$player_id))
 
-  player_df[is.na(player_df)] <- 0
+  player_df_nas <- is.na(player_df)
+  epa_index <- which(dimnames(player_df_nas)[[2]] %in% c("passing_epa", "rushing_epa", "receiving_epa", "dakota"))
+  player_df_nas[,epa_index] <- c(FALSE)
+
+  player_df[player_df_nas] <- 0
 
   player_df <- player_df %>%
     dplyr::mutate(

--- a/R/aggregate_game_stats.R
+++ b/R/aggregate_game_stats.R
@@ -447,7 +447,7 @@ calculate_player_stats <- function(pbp, weekly = FALSE) {
         passing_air_yards = sum(.data$passing_air_yards),
         passing_yards_after_catch = sum(.data$passing_yards_after_catch),
         passing_first_downs = sum(.data$passing_first_downs),
-        passing_epa = sum(.data$passing_epa, na.rm = TRUE),
+        passing_epa = dplyr::if_else(all(is.na(.data$passing_epa)), NA_real_, sum(.data$passing_epa, na.rm = TRUE)),
         passing_2pt_conversions = sum(.data$passing_2pt_conversions),
 
         # rushing
@@ -456,7 +456,7 @@ calculate_player_stats <- function(pbp, weekly = FALSE) {
         rushing_tds = sum(.data$rushing_tds),
         rushing_fumbles_lost = sum(.data$rushing_fumbles_lost),
         rushing_first_downs = sum(.data$rushing_first_downs),
-        rushing_epa = sum(.data$rushing_epa, na.rm = TRUE),
+        rushing_epa = dplyr::if_else(all(is.na(.data$rushing_epa)), NA_real_, sum(.data$rushing_epa, na.rm = TRUE)),
         rushing_2pt_conversions = sum(.data$rushing_2pt_conversions),
 
         # receiving
@@ -468,7 +468,7 @@ calculate_player_stats <- function(pbp, weekly = FALSE) {
         receiving_air_yards = sum(.data$receiving_air_yards),
         receiving_yards_after_catch = sum(.data$receiving_yards_after_catch),
         receiving_first_downs = sum(.data$receiving_first_downs),
-        receiving_epa = sum(.data$receiving_epa, na.rm = TRUE),
+        receiving_epa = dplyr::if_else(all(is.na(.data$receiving_epa)), NA_real_, sum(.data$receiving_epa, na.rm = TRUE)),
         receiving_2pt_conversions = sum(.data$receiving_2pt_conversions),
 
         # fantasy

--- a/R/aggregate_game_stats.R
+++ b/R/aggregate_game_stats.R
@@ -363,7 +363,7 @@ calculate_player_stats <- function(pbp, weekly = FALSE) {
         TRUE ~ .data$team_receiver
       )
     ) %>%
-    dplyr::select(
+    dplyr::select(tidyselect::any_of(c(
 
       # id information
       "player_id", "player_name", "recent_team", "season", "week",
@@ -382,7 +382,7 @@ calculate_player_stats <- function(pbp, weekly = FALSE) {
       "receiving_air_yards", "receiving_yards_after_catch",
       "receiving_first_downs", "receiving_epa", "receiving_2pt_conversions"
 
-    ) %>%
+    ))) %>%
     dplyr::filter(!is.na(.data$player_id))
 
   player_df[is.na(player_df)] <- 0

--- a/man/calculate_player_stats.Rd
+++ b/man/calculate_player_stats.Rd
@@ -41,6 +41,7 @@ NOTE: this uses the variable \code{qb_epa}, which gives QB credit for EPA for up
 to the point where a receiver lost a fumble after a completed catch and makes
 EPA work more like passing yards on plays with fumbles.}
 \item{passing_2pt_conversions}{Two-point conversion passes.}
+\item{dakota}{Adjusted EPA + CPOE composite based on coefficients which best predict adjusted EPA/play in the following year.}
 \item{carries}{The number of official rush attempts (incl. scrambles and kneel downs).
 Rushes after a lateral reception don't count as carry.}
 \item{rushing_yards}{Yards gained when rushing with the ball (incl. scrambles and kneel downs).


### PR DESCRIPTION
`calculate_player_stats` now adds dakota for players with at least 5 pass plays per game

also grouping by player_name in the final output duplicated some players with different names in the pbp (e.g. G.Minshew and G.Minshew III), instead the mode of player_name is used now