### PR TITLE
don't disconnect custom connection

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: nflfastR
 Title: Functions to Efficiently Access NFL Play by Play Data
-Version: 4.0.0.9009
+Version: 4.0.0.9010
 Authors@R: 
     c(person(given = "Sebastian",
              family = "Carl",

--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,7 @@
 * Fixed a bug where special teams touchdowns were missing in the output of `calculate_player_stats()` (#203)
 * The function `clean_pbp()` now standardizes the team name columns `tackle_with_assist_*_team`
 * Fixed for some old Jaguars games where the wrong team was awarded points for safeties and kickoff return TDs (#209)
+* The function `update_db()` no more falsely closes a database connection provided by the argument `db_connection` (#210)
 
 # nflfastR 4.0.0
 

--- a/R/helper_database_functions.R
+++ b/R/helper_database_functions.R
@@ -116,7 +116,7 @@ update_db <- function(dbdir = ".",
 
   message_completed("Database update completed", in_builder = TRUE)
   usethis::ui_info("{my_time()} | Path to your db: {usethis::ui_path(DBI::dbGetInfo(connection)$dbname)}")
-  DBI::dbDisconnect(connection)
+  if (is.null(db_connection)) DBI::dbDisconnect(connection)
   rule_footer("DONE")
 }
 


### PR DESCRIPTION
fixes #210 

if the user passes his own connection with the argument `db_connection` we should not close it after the update

There are probably users who worked around that by reconnecting to their DBs after `upodate_db()` closed the connection. 

I tested it and it's irrelevant if they try to connect to an already connected DB so we don't break any currently running scripts (I think)