### PR TITLE
Correct `yards_gained` for plays with laterals

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: nflfastR
 Title: Functions to Efficiently Access NFL Play by Play Data
-Version: 4.0.0.9012
+Version: 4.0.0.9013
 Authors@R: 
     c(person(given = "Sebastian",
              family = "Carl",

--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,7 @@
 * The function `update_db()` no more falsely closes a database connection provided by the argument `db_connection` (#210)
 * Added column `home_opening_kickoff` to `clean_pbp()`
 * Added the variables `sack_player_id`, `sack_player_name`, `half_sack_1_player_id`, `half_sack_1_player_name`, `half_sack_2_player_id` and `half_sack_2_player_name` who identify players that recorded sacks (or half sacks). Also updated the description of the variables `qb_hit_1_player_id`, `qb_hit_1_player_name`, `qb_hit_2_player_id` and `qb_hit_2_player_name` to make more clear that they did not record a sack. (#180)
+* Fixed a bug where `yards_gained` was missing yardage on plays with laterals. (#216)
 
 # nflfastR 4.0.0
 

--- a/R/helper_add_nflscrapr_mutations.R
+++ b/R/helper_add_nflscrapr_mutations.R
@@ -65,6 +65,17 @@ add_nflscrapr_mutations <- function(pbp) {
           .data$two_point_conv_result == "success",
         2, .data$yards_gained
       ),
+      # Fix yards_gained for plays with laterals
+      yards_gained = dplyr::case_when(
+        !is.na(.data$passing_yards) &
+          .data$yards_gained != .data$passing_yards &
+          .data$penalty == 0 ~ .data$passing_yards,
+        !is.na(.data$rushing_yards) &
+          !is.na(.data$lateral_rushing_yards) &
+          .data$yards_gained != .data$rushing_yards &
+          .data$penalty == 0 ~ .data$rushing_yards + .data$lateral_rushing_yards,
+        TRUE ~ yards_gained
+      ),
       # Extract the penalty type:
       penalty_type = dplyr::if_else(
         .data$penalty == 1,


### PR DESCRIPTION
fixes #216 

here's code that scrapes total offensive yards from nfl dot com and compares it to pbp summaries with the new fix.

If the `old_new_diff == TRUE` this means, that the fix in this PR changed the output for that team. And where `diff == NA` the pbp summary and the scraped data are identical. This is TRUE for all teams so the fix works fine.

``` r
library(dplyr, warn.conflicts = FALSE)
options(dplyr.summarise.inform = FALSE)
options(tibble.print_min = 32)
options(width = 200)

passing <- rvest::read_html("https://www.nfl.com/stats/team-stats/offense/passing/2020/reg/all") %>% 
  rvest::html_table() %>% 
  purrr::pluck(1) %>% 
  dplyr::mutate(Team = stringr::str_extract(Team, ".+(?=\\n)")) %>% 
  janitor::clean_names() %>% 
  dplyr::select(team:cmp, pass_yds, sck_y)

rushing <- rvest::read_html("https://www.nfl.com/stats/team-stats/offense/rushing/2020/reg/all") %>% 
  rvest::html_table() %>% 
  purrr::pluck(1) %>% 
  dplyr::mutate(Team = stringr::str_extract(Team, ".+(?=\\n)")) %>% 
  janitor::clean_names() %>% 
  dplyr::select(team:rush_yds)

overall <- passing %>% 
  dplyr::left_join(rushing, by = "team") %>% 
  dplyr::mutate(overall = pass_yds + rush_yds - sck_y) %>% 
  dplyr::arrange(dplyr::desc(overall)) %>% 
  dplyr::select(team, overall, pass_yds, rush_yds, sck_y) %>% 
  dplyr::left_join(
    nflfastR::teams_colors_logos %>% 
      dplyr::select(team_abbr, team = team_nick) %>% 
      dplyr::filter(!team_abbr %in% c("OAK", "SD", "STL", "LAR")), 
    by = "team"
  ) %>% 
  dplyr::select(team_abbr, overall, pass_yds, rush_yds, sck_y)


pbp_2020 <- nflfastR::load_pbp(2020)
pbp_2020 %>% 
  dplyr::filter(season_type == "REG", down %in% 1:4, play_type != "no_play") %>% 
  dplyr::mutate(
    new_yards_gained = dplyr::case_when(
      !is.na(.data$passing_yards) & 
        .data$yards_gained != .data$passing_yards & 
        .data$penalty == 0 ~ .data$passing_yards,
      !is.na(.data$rushing_yards) & 
        !is.na(.data$lateral_rushing_yards) & 
        .data$yards_gained != .data$rushing_yards & 
        .data$penalty == 0 ~ .data$rushing_yards + .data$lateral_rushing_yards,
      TRUE ~ yards_gained
    )
  ) %>% 
  dplyr::group_by(team_abbr = posteam) %>% 
  dplyr::summarise(
    old_pbp_yards = sum(yards_gained, na.rm = TRUE),
    new_pbp_yards = sum(new_yards_gained, na.rm = TRUE),
    passing = sum(passing_yards, na.rm = TRUE),
    rushing = sum(rushing_yards, na.rm = TRUE),
    lateral_rushing = sum(lateral_rushing_yards, na.rm = TRUE),
  ) %>% 
  dplyr::ungroup() %>% 
  dplyr::mutate(rushing = rushing + lateral_rushing) %>% 
  dplyr::select(-lateral_rushing) %>%
  dplyr::arrange(dplyr::desc(new_pbp_yards)) %>% 
  dplyr::mutate(old_new_diff = dplyr::if_else(old_pbp_yards == new_pbp_yards, NA, TRUE)) %>% 
  dplyr::right_join(overall, by = "team_abbr") %>% 
  dplyr::mutate(diff = dplyr::if_else(new_pbp_yards == overall, NA, TRUE))
#> # A tibble: 32 x 11
#>    team_abbr old_pbp_yards new_pbp_yards passing rushing old_new_diff overall pass_yds rush_yds sck_y diff 
#>    <chr>             <dbl>         <dbl>   <dbl>   <dbl> <lgl>          <int>    <int>    <int> <int> <lgl>
#>  1 KC                 6652          6653    5005    1799 TRUE            6653     5005     1799   151 NA   
#>  2 BUF                6343          6343    4786    1723 NA              6343     4786     1723   166 NA   
#>  3 TEN                6343          6343    3826    2690 NA              6343     3826     2690   173 NA   
#>  4 MIN                6292          6292    4265    2283 NA              6292     4265     2283   256 NA   
#>  5 GB                 6224          6224    4299    2118 NA              6224     4299     2118   193 NA   
#>  6 ARI                6153          6153    4102    2237 NA              6153     4102     2237   186 NA   
#>  7 TB                 6145          6145    4776    1519 NA              6145     4776     1519   150 NA   
#>  8 LV                 6133          6133    4383    1916 NA              6133     4383     1916   166 NA   
#>  9 LAC                6113          6113    4548    1784 NA              6113     4548     1784   219 NA   
#> 10 IND                6049          6049    4186    1996 NA              6049     4186     1996   133 NA   
#> 11 LA                 6032          6032    4183    2018 NA              6032     4183     2018   169 NA   
#> 12 NO                 6023          6023    3945    2265 NA              6023     3945     2265   187 NA   
#> 13 HOU                5982          6004    4843    1466 TRUE            6004     4843     1466   305 NA   
#> 14 DAL                5954          5949    4511    1788 TRUE            5949     4511     1788   350 NA   
#> 15 SF                 5903          5922    4320    1889 TRUE            5922     4320     1889   287 NA   
#> 16 CLE                5913          5913    3701    2374 NA              5913     3701     2374   162 NA   
#> 17 SEA                5912          5912    4245    1971 NA              5912     4245     1971   304 NA   
#> 18 ATL                5895          5895    4620    1532 NA              5895     4620     1532   257 NA   
#> 19 BAL                5810          5810    2919    3071 NA              5810     2919     3071   180 NA   
#> 20 DET                5603          5603    4397    1499 NA              5603     4397     1499   293 NA   
#> 21 CAR                5592          5592    4129    1704 NA              5592     4129     1704   241 NA   
#> 22 MIA                5424          5424    3937    1688 NA              5424     3937     1688   201 NA   
#> 23 DEN                5369          5369    3673    1918 NA              5369     3673     1918   222 NA   
#> 24 PHI                5354          5354    3728    2027 NA              5354     3728     2027   401 NA   
#> 25 PIT                5354          5354    4129    1351 NA              5354     4129     1351   126 NA   
#> 26 CHI                5302          5302    3925    1647 NA              5302     3925     1647   270 NA   
#> 27 NE                 5236          5236    3124    2346 NA              5236     3124     2346   234 NA   
#> 28 JAX                5218          5218    3955    1519 NA              5218     3955     1519   256 NA   
#> 29 CIN                5116          5116    3793    1668 NA              5116     3793     1668   345 NA   
#> 30 WAS                5076          5076    3796    1611 NA              5076     3796     1611   331 NA   
#> 31 NYG                4794          4794    3336    1768 NA              4794     3336     1768   310 NA   
#> 32 NYJ                4479          4479    3115    1683 NA              4479     3115     1683   319 NA
```

<sup>Created on 2021-03-14 by the [reprex package](https://reprex.tidyverse.org) (v1.0.0)</sup>